### PR TITLE
[DAT-8952] Fixes antivirus updates failing to download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,18 @@ RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2
+RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle libtool-ltdl
 RUN rpm2cpio clamav-0*.rpm | cpio -idmv
 RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
 RUN rpm2cpio clamav-update*.rpm | cpio -idmv
 RUN rpm2cpio json-c*.rpm | cpio -idmv
 RUN rpm2cpio pcre*.rpm | cpio -idmv
+RUN rpm2cpio gnutls*.rpm | cpio -idmv
+RUN rpm2cpio nettle*.rpm | cpio -idmv
+RUN rpm2cpio libprelude*.rpm | cpio -idmv
+RUN rpm2cpio libtasn1*.rpm | cpio -idmv
+RUN rpm2cpio libtool-ltdl*.rpm | cpio -idmv
+
 
 # Copy over the binaries and libraries
 RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /opt/app/bin/

--- a/update.py
+++ b/update.py
@@ -23,13 +23,18 @@ from common import AV_DEFINITION_S3_BUCKET
 from common import AV_DEFINITION_S3_PREFIX
 from common import CLAMAVLIB_PATH
 from common import get_timestamp
-
+import shutil
 
 def lambda_handler(event, context):
     s3 = boto3.resource("s3")
     s3_client = boto3.client("s3")
 
     print("Script starting at %s\n" % (get_timestamp()))
+
+    #clean /tmp on the ec2 instance because it doesn't clean itself
+    if os.path.exists(os.path.join(AV_DEFINITION_PATH,'')):
+        shutil.rmtree(os.path.join(AV_DEFINITION_PATH, ''))
+
     to_download = clamav.update_defs_from_s3(
         s3_client, AV_DEFINITION_S3_BUCKET, AV_DEFINITION_S3_PREFIX
     )


### PR DESCRIPTION
This job writes to /tmp/ by default the only writeable location in Lambda
If AWS fails to provision a new instance for repeated runs can fill /tmp/
as it's not cleared between runs if the instance is re-used

This commit clears /tmp/ after a run. It also updates the Dockerfile with
several dependencies as the base image has changed since our last
rebuild.

Tested in production becaue things were broke.
<insert bill oreilly gif here>